### PR TITLE
Update Yarn Version in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.6.0
 
-      - name: Setup Yarn
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Update Yarn
         run: yarn set version stable

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,9 @@ jobs:
           corepack enable
           corepack prepare yarn@stable --activate
 
+      - name: Update Yarn
+        run: yarn set version stable
+
       - name: Cache deps
         uses: actions/cache@v3.3.1
         with:

--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
   },
-  "packageManager": "yarn@3.6.1"
+  "packageManager": "yarn@3.6.3"
 }


### PR DESCRIPTION
This pull request modifies the following stuffs:

- Introduces an "Update Yarn" step in the workflow to update the current Yarn version to stable.
- Replaces the "Setup Yarn" step with an "Enable Corepack" step in the workflow.
- Upgrades Yarn to version 3.6.3.

It resolves #26.