### PR TITLE
Utilize Setup Yarn Berry Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,20 +17,10 @@ jobs:
         with:
           node-version: latest
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Update Yarn
-        run: yarn set version stable
-
-      - name: Cache deps
-        uses: actions/cache@v4.0.2
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@v2.0.0
         with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
-      - name: Install deps
-        run: yarn install
+          version: stable
 
       - name: Check format
         run: yarn sort && yarn format


### PR DESCRIPTION
This pull request resolves #136 by replacing most steps in the `build` workflow to enable Yarn, cache Yarn installation, and install packages with a single step that calls [Setup Yarn Berry Action](https://github.com/threeal/setup-yarn-action).