### PR TITLE
Setup Latest Node.js in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.1
+        with:
+          node-version: latest
+
       - name: Enable Corepack
         run: corepack enable
 


### PR DESCRIPTION
This pull request resolves #138 by setting up the latest Node.js version in the `build` workflow, utilizing the [Setup Node Action](https://github.com/actions/setup-node/).