### PR TITLE
Remove `latest` Branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,8 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["*", "!latest"]
   push:
-    branches: [latest, main]
+    branches: [main]
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
This pull request resolves #146 by removing the `latest` branch from triggering workflow run.