### PR TITLE
Bump Yarn to Version 4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
     "sort-package-json": "^2.10.0",
     "typescript": "^5.4.5"
   },
-  "packageManager": "yarn@4.2.1"
+  "packageManager": "yarn@4.2.2"
 }


### PR DESCRIPTION
This pull request simply bumps Yarn to version [4.2.2](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.2.2).