### PR TITLE
Unspecify Yarn Version in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Check format
         run: yarn format


### PR DESCRIPTION
This pull request resolves #249 by not specifying the Yarn version when setting up Yarn in GitHub workflows.