### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #267 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.