### PR TITLE
Move Built Dependencies Config to `pnpm-workspace.yaml`

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,7 @@ pre-commit:
       glob:
         - package.json
         - pnpm-lock.yaml
+        - pnpm-workspace.yaml
 
     - name: fix formatting
       run: pnpm prettier --write --ignore-unknown {staged_files}

--- a/package.json
+++ b/package.json
@@ -32,13 +32,5 @@
   },
   "resolutions": {
     "puppeteer": "23.2.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "lefthook",
-      "puppeteer",
-      "sharp",
-      "sleep"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+onlyBuiltDependencies:
+  - lefthook
+  - puppeteer
+  - sharp
+  - sleep


### PR DESCRIPTION
This pull request resolves #470 by moving the `onlyBuiltDependencies` config from the `package.json` file to the `pnpm-workspace.yaml` file.