### PR TITLE
Separate TypeScript Build Configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm eslint
 
       - name: Check Types
-        run: pnpm tsc --noEmit
+        run: pnpm tsc
 
       - name: Package Project
         run: pnpm pack

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,9 +15,9 @@ pre-commit:
       run: pnpm eslint --no-warn-ignored --fix {staged_files}
 
     - name: check types
-      run: pnpm tsc --noEmit
+      run: pnpm tsc
       glob:
-        - src/*.ts
+        - "*.ts"
         - .npmrc
         - pnpm-lock.yaml
         - tsconfig.json

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "tsc",
+    "prepack": "tsc -p tsconfig.build.json",
     "start": "jiti src/bin.ts"
   },
   "dependencies": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node24",
+  "include": ["src"],
   "compilerOptions": {
-    "noEmit": true
+    "outDir": "dist"
   }
 }


### PR DESCRIPTION
This pull request resolves #478 by separating the TypeScript configurations into `tsconfig.json` for type checking and `tsconfig.build.json` for building the library.