### PR TITLE
Lock pnpm to Version 10.33.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1"
   },
+  "packageManager": "pnpm@10.33.4",
   "resolutions": {
     "puppeteer": "23.2.0"
   }


### PR DESCRIPTION
This pull request resolves #676 by locking the pnpm version used in this project to version 10.33.4 both in the GitHub Actions workflow and `package.json`.