### PR TITLE
Use `allowBuilds` in `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 packages: [.]
-onlyBuiltDependencies:
-  - lefthook
-  - puppeteer
-  - sharp
-  - sleep
+allowBuilds:
+  lefthook: true
+  puppeteer: true
+  sharp: true
+  sleep: true


### PR DESCRIPTION
It resolves #697 by replacing the deprecated `onlyBuiltDependencies` field with the new `allowBuilds` format in `pnpm-workspace.yaml`.

The `allowBuilds` field is the current pnpm configuration for controlling which packages are allowed to run lifecycle scripts during installation.