### PR TITLE
Remove `packages` option from `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
-packages: [.]
 allowBuilds:
   lefthook: true
   puppeteer: true


### PR DESCRIPTION
This pull request resolves #699 by removing the `packages` option from `pnpm-workspace.yaml`, simplifying the workspace configuration.